### PR TITLE
Sensitivity matrix

### DIFF
--- a/catalax/__init__.py
+++ b/catalax/__init__.py
@@ -1,8 +1,13 @@
 from .model import Model
+from .model import InAxes
 from .tools.optimization import optimize
 from .tools.visualization import visualize
 
 __version__ = "0.2.0"
+
+PARAMETERS = InAxes.PARAMETERS
+TIME = InAxes.TIME
+INITS = InAxes.Y0
 
 
 def set_host_count(n: int = 1):

--- a/catalax/model/__init__.py
+++ b/catalax/model/__init__.py
@@ -1,1 +1,2 @@
 from .model import Model
+from .inaxes import InAxes

--- a/catalax/model/inaxes.py
+++ b/catalax/model/inaxes.py
@@ -1,0 +1,22 @@
+from enum import Enum
+
+
+class InAxes(Enum):
+    PARAMETERS = (None, 0, None)
+    TIME = (None, None, 0)
+    Y0 = (0, None, None)
+
+    # Override add function to combine axes
+    def __add__(self, other):
+        assert isinstance(other, InAxes), "Other spec must be an instance of InAxes"
+
+        merge = (
+            lambda i: 0
+            if any(spec.value[i] is not None for spec in [self, other])
+            else None
+        )
+        return (
+            merge(0),
+            merge(1),
+            merge(2),
+        )


### PR DESCRIPTION
* Integration mode can be changed to sensitivity (jacobian) of the solution

```python
import catalax as ctx

sensitivities = model.simulate(
    initial_conditions,
    t0=0, t1=1000, nsteps=100,
    in_axes=ctx.INITS, sensitivity=ctx.PARAMETERS,
)
```