### PR TITLE
Add dynamic solver usage and `arviz` import

### DIFF
--- a/catalax/dataset/measurement.py
+++ b/catalax/dataset/measurement.py
@@ -543,7 +543,7 @@ class Measurement(BaseModel):
                 **plt_kwargs,
             )
 
-            if model_data:
+            if model_data and species in sim_meas:
                 ax.plot(
                     sim_meas["time"],
                     sim_meas[species],

--- a/catalax/mcmc/mcmc.py
+++ b/catalax/mcmc/mcmc.py
@@ -17,6 +17,7 @@ from typing import (
 
 import jax
 import jax.numpy as jnp
+import diffrax
 import numpyro
 import numpyro.distributions as dist
 from jax import Array
@@ -63,7 +64,7 @@ class MCMCConfig:
     seed: int = 420
     verbose: int = 1
     max_steps: int = 64**4
-    solver: str = "scipy"
+    solver: Type[diffrax.AbstractSolver] = diffrax.Tsit5
 
 
 class Modes(Enum):
@@ -114,6 +115,7 @@ class HMC:
         seed: int = 420,
         verbose: int = 1,
         max_steps: int = 64**4,
+        solver: Type[diffrax.AbstractSolver] = diffrax.Tsit5,
     ):
         """Initialize HMC sampler.
 
@@ -130,6 +132,7 @@ class HMC:
             seed: Random seed for reproducibility
             verbose: Verbosity level; 0 for silent, 1 for progress
             max_steps: Maximum number of integration steps
+            solver: Solver to use for simulation
         """
         self.config = MCMCConfig(
             num_warmup=num_warmup,
@@ -139,6 +142,7 @@ class HMC:
             thinning=thinning,
             max_tree_depth=max_tree_depth,
             dt0=dt0,
+            solver=solver,
             chain_method=chain_method,
             num_chains=num_chains,
             seed=seed,
@@ -170,7 +174,7 @@ class HMC:
             surrogate: Optional surrogate model for rate prediction
             pre_model: Optional function to transform inputs and parameters before simulation
             post_model: Optional function to transform outputs after simulation
-
+            solver: Solver to use for simulation
         Returns:
             Tuple of (MCMC object with results, Bayesian model function)
 
@@ -184,7 +188,13 @@ class HMC:
         _validate_model_functions(pre_model, post_model)
 
         # Setup model and prepare data
-        data_prep = _prepare_mcmc_data(dataset, model, surrogate)
+        data_prep = _prepare_mcmc_data(
+            dataset,
+            model,
+            surrogate,
+            self.config.solver,
+            self.config.dt0,
+        )
 
         if surrogate is not None:
             mode = Modes.SURROGATE
@@ -201,6 +211,8 @@ class HMC:
             post_model=post_model,
             shapes=data_prep.shapes,
             mode=mode,
+            solver=self.config.solver,
+            dt0=self.config.dt0,
         )
 
         # Initialize and run MCMC
@@ -244,6 +256,7 @@ class HMC:
             verbose=config.verbose,
             max_steps=config.max_steps,
             dt0=config.dt0,
+            solver=config.solver,
         )
 
 
@@ -263,8 +276,10 @@ class BayesianModel:
         sim_func: Callable,
         shapes: Shapes,
         mode: Modes,
+        solver: Type[diffrax.AbstractSolver],
         pre_model: Optional[PreModel] = None,
         post_model: Optional[PostModel] = None,
+        dt0: float = 0.1,
     ):
         """Initialize the Bayesian model.
 
@@ -286,6 +301,8 @@ class BayesianModel:
         self.post_model = post_model
         self.shapes = shapes
         self.mode = mode
+        self.solver = solver
+        self.dt0 = dt0
 
         # Pre-compute priors and observables
         self.priors = [
@@ -378,6 +395,8 @@ def run_mcmc(
     surrogate: Optional[Surrogate] = None,
     pre_model: Optional[PreModel] = None,
     post_model: Optional[PostModel] = None,
+    solver: Type[diffrax.AbstractSolver] = diffrax.Tsit5,
+    dt0: float = 0.1,
 ) -> HMCResults:
     """Run MCMC simulation to infer posterior distribution of parameters.
 
@@ -405,13 +424,15 @@ def run_mcmc(
     """
     # Validate inputs
     hmc = HMC.from_config(config)
-    return hmc.run(model, dataset, yerrs, surrogate, pre_model, post_model)
+    return hmc.run(model, dataset, yerrs, surrogate, pre_model, post_model, solver, dt0)
 
 
 def _prepare_mcmc_data(
     dataset: Dataset,
     model: "Model",
     surrogate: Optional[Surrogate],
+    solver: Type[diffrax.AbstractSolver],
+    dt0: float,
 ) -> DataPreparation:
     """Prepare all data components needed for MCMC simulation.
 
@@ -449,6 +470,8 @@ def _prepare_mcmc_data(
         y0s=y0s,
         times=times,
         constants=constants,
+        solver=solver,
+        dt0=dt0,
     )
 
     return DataPreparation(
@@ -665,6 +688,8 @@ def _configure_simulation_function(
     y0s: Array,
     times: Array,
     constants: Array,
+    dt0: float,
+    solver: Type[diffrax.AbstractSolver],
 ) -> Tuple[Callable, Array, Array, Array, Array]:
     """Configure the appropriate simulation function based on model type.
 
@@ -708,10 +733,11 @@ def _configure_simulation_function(
             parameters=model.get_parameter_order(),
             stoich_mat=model._get_stoich_mat(),
             constants=model.get_constants_order(),
-            dt0=0.1,  # Default dt0
+            dt0=dt0,
             rtol=1e-5,
             atol=1e-5,
             max_steps=64**4,
+            solver=solver,
         )
 
         # Set up simulation with correct in_axes for MCMC

--- a/catalax/mcmc/mcmc.py
+++ b/catalax/mcmc/mcmc.py
@@ -424,7 +424,7 @@ def run_mcmc(
     """
     # Validate inputs
     hmc = HMC.from_config(config)
-    return hmc.run(model, dataset, yerrs, surrogate, pre_model, post_model, solver, dt0)
+    return hmc.run(model, dataset, yerrs, surrogate, pre_model, post_model)
 
 
 def _prepare_mcmc_data(

--- a/catalax/mcmc/results.py
+++ b/catalax/mcmc/results.py
@@ -83,8 +83,8 @@ class HMCResults:
             Model: New model instance with parameters updated from posterior samples.
                 The returned model can be used for predictions with fitted parameters.
         """
-        return self.model.from_samples(
-            self.mcmc.get_samples(),
+        return self.model.from_arviz(
+            az.from_numpyro(self.mcmc),
             hdi_prob=hdi_prob,
             set_bounds=set_bounds,
         )


### PR DESCRIPTION
This pull request introduces significant improvements to the simulation and training workflow by enabling flexible solver selection for MCMC and neural ODE routines, and by enhancing model fitting from posterior samples. The changes make it easier to specify and propagate numerical solvers throughout the codebase, improving extensibility and reproducibility. Additionally, model fitting now leverages ArviZ for robust handling of posterior samples and HDI bounds.

### Solver Flexibility and Propagation

* Added support for specifying a `diffrax` solver (e.g., `diffrax.Tsit5`) throughout the MCMC configuration and workflow, including `MCMCConfig`, `HMC` initialization, and simulation functions. This allows users to choose and propagate custom solvers for numerical integration. [[1]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394R20) [[2]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394L66-R67) [[3]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394R118) [[4]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394R135) [[5]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394R145) [[6]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394L173-R177) [[7]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394L187-R197) [[8]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394R214-R215) [[9]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394R259) [[10]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394R279-R282) [[11]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394R304-R305) [[12]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394R398-R399) [[13]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394L408-R435) [[14]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394R473-R474) [[15]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394R691-R692) [[16]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394L711-R740)
* Extended neural training routines (`NeuralBase.train`, `train_neural_ode`) to accept and propagate solver choices, including logic for adaptive and non-adaptive controllers. [[1]](diffhunk://#diff-0c82fae4d4b7dcc4cf9d023239a984583e07bf854348049d74031571331ddc72R115) [[2]](diffhunk://#diff-0c82fae4d4b7dcc4cf9d023239a984583e07bf854348049d74031571331ddc72R169) [[3]](diffhunk://#diff-0c82fae4d4b7dcc4cf9d023239a984583e07bf854348049d74031571331ddc72L465-R473) [[4]](diffhunk://#diff-3d8745a0ec28a5fae62920b17e6110228794f388cf3f2f07725a6b4bc4b2d957L3-R11) [[5]](diffhunk://#diff-3d8745a0ec28a5fae62920b17e6110228794f388cf3f2f07725a6b4bc4b2d957R40) [[6]](diffhunk://#diff-3d8745a0ec28a5fae62920b17e6110228794f388cf3f2f07725a6b4bc4b2d957R62-R68)

### Model Fitting and Posterior Handling

* Added a new `from_arviz` method to `Model` for creating fitted models directly from ArviZ posterior samples, including HDI extraction and robust handling of NaN bounds. Updated `get_fitted_model` to use this method. [[1]](diffhunk://#diff-8cb9b5cbfa98946fd92a8f5024cf59bfb5b0f5e73941fa0923f1751762ed842cL86-R87) [[2]](diffhunk://#diff-602724c635619378aaa059ca6498d03d90409f093d1b5f33201499fd96a6efbaR1039-R1098)

### Miscellaneous Improvements

* Minor bug fix in measurement plotting to ensure simulated measurements are only plotted when available for the species.
* Minor code cleanups and improvements to logging and metric calculations in neural training routines. [[1]](diffhunk://#diff-3d8745a0ec28a5fae62920b17e6110228794f388cf3f2f07725a6b4bc4b2d957R215) [[2]](diffhunk://#diff-3d8745a0ec28a5fae62920b17e6110228794f388cf3f2f07725a6b4bc4b2d957R300)