### PR TITLE
Support `{state}_init` symbols for initial values in equations

### DIFF
--- a/catalax/mcmc/mcmc.py
+++ b/catalax/mcmc/mcmc.py
@@ -66,6 +66,7 @@ class MCMCConfig:
     verbose: int = 1
     max_steps: int = 64**4
     solver: Type[diffrax.AbstractSolver] = diffrax.Tsit5
+    target_accept_prob: float = 0.8
 
     def to_simulation_config(self) -> SimulationConfig:
         return SimulationConfig(
@@ -254,6 +255,7 @@ class HMC:
             bayes_model,
             dense_mass=self.config.dense_mass,
             max_tree_depth=self.config.max_tree_depth,
+            target_accept_prob=self.config.target_accept_prob,
         )
         mcmc = MCMC(
             nuts,
@@ -416,7 +418,10 @@ class BayesianModel:
         # Expand yerrs to match shape of states
         sigma_disc = numpyro.sample(
             "sigma",
-            dist.Normal(0.0, jnp.mean(self.yerrs[..., self.observables])),
+            dist.Normal(
+                0.0,
+                jnp.mean(self.yerrs[..., self.observables]),
+            ),
         )  # type: ignore
 
         sigma_total = sigma_disc**2
@@ -762,16 +767,30 @@ def _configure_simulation_function(
 
     if surrogate is not None:
         print("Using surrogate model for rate prediction")
-        # Use surrogate model for rate prediction
+        # Use surrogate model for rate prediction. Here y0s is repurposed as the
+        # flattened state points at which rates are evaluated, grouped per
+        # measurement (n_measurements * n_time, n_states).
         data, times, _ = dataset.to_jax_arrays(model.get_state_order())
         constants = dataset.to_y0_matrix(state_order=model.get_constants_order())
         rate_fun = model._setup_rate_function(in_axes=None)
+        n_time = data.shape[1]
         y0s = data.reshape(-1, data.shape[-1])
 
-        def sim_func(y0s, theta, constants, times):
-            return rate_fun(times, y0s, (theta, constants))
+        def _rate_at_point(y0s, theta, constants, times, inits):
+            return rate_fun(times, y0s, (theta, constants, inits))
 
-        sim_func = jax.jit(jax.vmap(sim_func, in_axes=(0, None, 0, 0)))
+        vmapped_rate = jax.jit(jax.vmap(_rate_at_point, in_axes=(0, None, 0, 0, 0)))
+
+        def sim_func(y0s, theta, constants, times):
+            # Resolve "{state}_init" symbols from the t=0 state of each
+            # measurement, broadcast across its time points. Deriving the inits
+            # from y0s (rather than capturing the dataset values) ensures that
+            # sampled/transformed initial conditions are reflected here too.
+            n_states = y0s.shape[-1]
+            init_per_meas = y0s.reshape(-1, n_time, n_states)[:, 0, :]
+            inits = jnp.repeat(init_per_meas, n_time, axis=0)
+            return vmapped_rate(y0s, theta, constants, times, inits)
+
         times = times.ravel()
         constants = jnp.repeat(constants, data.shape[1], axis=0)
         data = surrogate.predict_rates(dataset=dataset)

--- a/catalax/model/equation.py
+++ b/catalax/model/equation.py
@@ -23,6 +23,7 @@ class Equation(CatalaxBase):
     )
 
     equation: AnnotatedExpr
+    inits: set[str] = Field(default_factory=set)
     parameters: Dict[Union[str, Expr], Parameter] = Field(
         default_factory=DottedDict,
         exclude=True,
@@ -58,6 +59,17 @@ class Equation(CatalaxBase):
         for symbol in self.equation.free_symbols:
             if str(symbol) in self._model.states or str(symbol) == "t":
                 # Skip state and time symbol
+                continue
+            elif str(symbol).endswith("_init"):
+                # Save inits for the ODE
+                state, *_ = str(symbol).split("_init")
+
+                if state not in self._model.states:
+                    raise ValueError(
+                        f"State '{state}' not found in the model for initial value statement '{symbol}'"
+                    )
+
+                self.inits.add(state)
                 continue
             elif str(symbol) in self._model.constants:
                 # Skip constants

--- a/catalax/model/model.py
+++ b/catalax/model/model.py
@@ -301,7 +301,7 @@ class Model(CatalaxBase, Predictor, Surrogate):
         )
         self.reactions[symbol]._model = self
 
-    def add_assignment(self, symbol: str, equation: str):
+    def add_assignment(self, symbol: str, equation: str, **kwargs):
         """Adds an assignment to the model and converts the equation to a SymPy expression."""
 
         if symbol in self.assignments:
@@ -982,8 +982,21 @@ class Model(CatalaxBase, Predictor, Surrogate):
         return sorted(observable_states)
 
     def get_constants_order(self) -> List[str]:
-        """Returns the order of the constants in the model"""
-        return sorted(list(self.constants.keys()))
+        """Returns the order of the constants in the model.
+
+        Initial-value symbols of the form "{state}_init" are excluded even if
+        declared as constants: their values are resolved from the initial
+        conditions (y0) at simulation time rather than from the constants
+        matrix, so they must not be requested from the dataset.
+        """
+        return sorted(
+            name for name in self.constants.keys() if not self._is_init_symbol(name)
+        )
+
+    def _is_init_symbol(self, name: str) -> bool:
+        """Whether `name` is an initial-value reference of the form "{state}_init"."""
+        suffix = "_init"
+        return name.endswith(suffix) and name[: -len(suffix)] in self.states
 
     def _warmup_simulation(
         self,

--- a/catalax/tools/simulation.py
+++ b/catalax/tools/simulation.py
@@ -263,7 +263,9 @@ class Simulation(BaseModel):
                 t1=time[-1],
                 dt0=self.config.dt0,
                 y0=y0,
-                args=(parameters, constants),
+                # y0 is forwarded as a third arg so equations can reference the
+                # initial value of a state via "{state}_init" symbols.
+                args=(parameters, constants, y0),
                 saveat=SaveAt(ts=time),
                 stepsize_controller=controller,
                 max_steps=self.config.max_steps,

--- a/catalax/tools/stack.py
+++ b/catalax/tools/stack.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Self
+from typing import TYPE_CHECKING, List, Optional, Self
 
 import equinox as eqx
 import jax
@@ -50,6 +50,10 @@ class BaseStack(eqx.Module):
             "parameters": sim_input.parameters,
             "constants": sim_input.constants,
             "states": sim_input.states,
+            # Initial-value symbols "{state}_init" are looked up positionally
+            # against the y0 array (which is ordered by state order), allowing
+            # an equation to reuse the initial value of a state.
+            "inits": [f"{state}_init" for state in sim_input.states],
         }
 
         self.modules = [
@@ -63,6 +67,7 @@ class BaseStack(eqx.Module):
         y: jax.Array,
         parameters: jax.Array,
         constants: jax.Array,
+        inits: Optional[jax.Array] = None,
     ):
         """
         Evaluate all modules in the stack.
@@ -76,10 +81,14 @@ class BaseStack(eqx.Module):
             y: Current state vector
             parameters: Parameter values array
             constants: Constant values array
+            inits: Optional initial-value array (y0) ordered by state order,
+                used to resolve "{state}_init" symbols. When ``None`` (e.g. when
+                evaluating rates outside of a simulation) no inits are exposed.
 
         Returns:
             jax.Array: Stacked results from all module evaluations
         """
+        extra = {} if inits is None else {"inits": inits}
         return jnp.stack(
             [
                 module(  # type: ignore
@@ -87,6 +96,7 @@ class BaseStack(eqx.Module):
                     parameters=parameters,
                     states=y,
                     constants=constants,
+                    **extra,
                 )
                 for module in self.modules
             ],
@@ -158,8 +168,9 @@ class ODEStack(BaseStack):
         Returns:
             jax.Array: Stack of evaluated rates for all ODE equations
         """
-        parameters, constants = args
-        return self._evaluate_modules(t, y, parameters, constants)
+        parameters, constants, *rest = args
+        inits = rest[0] if rest else None
+        return self._evaluate_modules(t, y, parameters, constants, inits)
 
     def fill_zero_modules(self, used_states: List[str], all_states: List[str]) -> Self:
         """
@@ -233,8 +244,9 @@ class ReactionStack(BaseStack):
         Returns:
             jax.Array: Net rates of change for each state
         """
-        parameters, constants = args
-        rates = self._evaluate_modules(t, y, parameters, constants)
+        parameters, constants, *rest = args
+        inits = rest[0] if rest else None
+        rates = self._evaluate_modules(t, y, parameters, constants, inits)
         return self.stoich_mat @ rates
 
     def fill_zero_modules(self, used_states: List[str], all_states: List[str]) -> Self:

--- a/docs/basic/model-class.mdx
+++ b/docs/basic/model-class.mdx
@@ -133,6 +133,24 @@ model.add_odes(
 - **Observable states**: By default, all states are observable; use `observable=False` for hidden states
 - **Validation**: The system checks for invalid states not yet added to the model.
 
+#### Referencing Initial Values with `_init`
+
+Equations can reference the **initial value** of any state using the `{state}_init` suffix. While a bare state symbol (e.g. `S`) refers to the current, time-varying value, `S_init` resolves to the concentration the state was initialized with at the start of the simulation.
+
+```python
+# `S` is the current value; `S_init` is the initial value of S
+model.add_ode("S", "-k * S")        # S decays exponentially
+model.add_ode("P", "k * S_init")    # P grows at a rate set by the initial S
+```
+
+This is useful whenever a rate should depend on a starting concentration rather than the current one — for example, normalizing against a total initial pool or driving a term by an initial loading.
+
+**Key points:**
+
+- The referenced state must already exist in the model, otherwise a `ValueError` is raised.
+- `_init` symbols are **not** registered as parameters; they are resolved from the simulation's initial conditions per measurement.
+- The same equation can mix current values and initial values freely (e.g. `S / S_init`).
+
 ### Step 4: Parameter Configuration
 
 Configure model parameters with values, bounds, and constraints:

--- a/tests/integration/test_mcmc.py
+++ b/tests/integration/test_mcmc.py
@@ -147,7 +147,6 @@ class TestMCMC:
         transformed (e.g. via ``estimate_initials``) the inits reflect those new
         values rather than the static dataset values.
         """
-        import jax
         from catalax.mcmc.mcmc import (
             _configure_simulation_function,
             _extract_dataset_components,

--- a/tests/integration/test_mcmc.py
+++ b/tests/integration/test_mcmc.py
@@ -137,3 +137,136 @@ class TestMCMC:
             pre_model=pre_model,
             yerrs=1.0,
         )
+
+    def test_init_symbol_surrogate_tracks_sampled_y0s(self):
+        """Surrogate rate path must resolve "{state}_init" from the live y0s.
+
+        In the surrogate path y0s is repurposed as the flattened state points at
+        which rates are evaluated. The init symbols must be derived from the t=0
+        state of each measurement *as passed in*, so that when y0s are sampled or
+        transformed (e.g. via ``estimate_initials``) the inits reflect those new
+        values rather than the static dataset values.
+        """
+        import jax
+        from catalax.mcmc.mcmc import (
+            _configure_simulation_function,
+            _extract_dataset_components,
+        )
+        from catalax.surrogate import Surrogate
+
+        # Model whose rate depends solely on s0_init (k * s0_init), so the rate
+        # of each evaluated point is determined entirely by the initial value.
+        model = Model(name="InitSurrogate")
+        model.add_state(s0="A", s1="B")
+        model.add_constant(s0_init="initial of s0")
+        model.add_assignment(symbol="rate", equation="k * s0_init")
+        model.add_ode("s0", "-rate")
+        model.add_ode("s1", "rate")
+        model.parameters["k"].value = 0.5
+
+        dataset = Dataset.from_model(model)
+        dataset.add_initial(s0=2.0, s1=0.0)
+        dataset.add_initial(s0=4.0, s1=0.0)
+        config = SimulationConfig(nsteps=3, t0=0, t1=2)
+        simulated = model.simulate(dataset=dataset, config=config)
+
+        n_time = 3
+
+        class _StubSurrogate(Surrogate):
+            """Minimal surrogate; only predict_rates is touched by the branch."""
+
+            def rates(self, t, y, constants=None):
+                return jnp.zeros_like(y)
+
+            def predict_rates(self, dataset, return_individual=False):
+                n_states = len(model.get_state_order())
+                n_points = len(dataset.measurements) * n_time
+                return jnp.zeros((n_points, n_states))
+
+            @property
+            def has_uncertainty(self):
+                return False
+
+            def rate_uncertainty(self, dataset):
+                return jnp.zeros(())
+
+            def rate_sigma(self, dataset):
+                return jnp.zeros(())
+
+        data, times, y0s, constants = _extract_dataset_components(simulated, model)
+        sim_func, _, y0s, times, constants = _configure_simulation_function(
+            model=model,
+            surrogate=_StubSurrogate(),
+            dataset=simulated,
+            data=data,
+            y0s=y0s,
+            times=times,
+            constants=constants,
+            config=config,
+        )
+
+        theta = jnp.array(
+            [model.parameters[p].value for p in model.get_parameter_order()]
+        )
+
+        def s1_rates(y0s_in):
+            # Returns the s1 rate for every flattened point (== k * s0_init).
+            return sim_func(y0s_in, theta, constants, times)[:, 1]
+
+        # Baseline: rate == k * s0_init, constant across each measurement's
+        # points (0.5 * 2.0 = 1.0 for meas 0, 0.5 * 4.0 = 2.0 for meas 1).
+        base = s1_rates(y0s)
+        assert jnp.allclose(base[:n_time], 1.0), base[:n_time]
+        assert jnp.allclose(base[n_time:], 2.0), base[n_time:]
+
+        n_states = y0s.shape[-1]
+        grouped = y0s.reshape(-1, n_time, n_states)
+
+        # "Sampling" the initial conditions: bump the t=0 state of measurement 0
+        # to 10.0 -> every point of that measurement must now use s0_init=10.0.
+        sampled = grouped.at[0, 0, 0].set(10.0).reshape(-1, n_states)
+        sampled_rates = s1_rates(sampled)
+        assert jnp.allclose(sampled_rates[:n_time], 5.0), sampled_rates[:n_time]
+        assert jnp.allclose(sampled_rates[n_time:], 2.0), sampled_rates[n_time:]
+
+        # Changing a NON-initial point (t>0) must NOT change the init term,
+        # confirming the initial value (t=0) is what gets reused.
+        non_init = grouped.at[0, 1, 0].set(999.0).reshape(-1, n_states)
+        non_init_rates = s1_rates(non_init)
+        assert jnp.allclose(non_init_rates, base), non_init_rates
+
+    def test_init_symbol_with_estimated_initials(self):
+        """Full-simulation MCMC with sampled y0s on an init-using model.
+
+        ``estimate_initials`` samples the initial conditions (y0s). Because the
+        simulation path forwards y0 as the source of "{state}_init" symbols, the
+        sampled initial conditions must flow into the inits automatically. This
+        exercises the whole pipeline end-to-end and guards against the
+        "Array 'inits' for positional arguments is missing" regression.
+        """
+        model = Model(name="InitEstimated")
+        model.add_state(s="Substrate", p="Product")
+        model.add_constant(s_init="initial of s")
+        model.add_assignment(symbol="rate", equation="k * s_init")
+        model.add_ode("s", "-rate")
+        model.add_ode("p", "rate")
+        model.parameters["k"].value = 0.5
+        model.parameters["k"].prior = Uniform(low=1e-6, high=5.0)
+
+        dataset = Dataset.from_model(model)
+        dataset.add_initial(s=2.0, p=0.0)
+        dataset.add_initial(s=4.0, p=0.0)
+        config = SimulationConfig(nsteps=5, t0=0, t1=2)
+        simulated = model.simulate(dataset=dataset, config=config)
+
+        hmc = cmc.HMC.from_config(cmc.MCMCConfig(num_warmup=20, num_samples=20))
+        results = hmc.run(
+            model,
+            simulated,
+            pre_model=estimate_initials(),
+            yerrs=1.0,
+        )
+
+        # The sampled initial conditions must appear in the posterior, proving
+        # y0s were sampled while the init-using model ran without error.
+        assert "estimated_y0s" in results.get_samples()

--- a/tests/integration/test_simulation.py
+++ b/tests/integration/test_simulation.py
@@ -141,3 +141,55 @@ class TestSimulation:
         assert jnp.abs(actual_s_1 - expected_s_1).sum() < TOLERANCE, (  # type: ignore
             f"s should decay exponentially. Expected: {expected_s_1}, Got: {actual_s_1}"
         )
+
+    def test_init_symbol_declared_as_constant(self):
+        """Test "{state}_init" when declared as a constant and used in an assignment.
+
+        Models loaded from JSON often declare the init symbol explicitly as a
+        constant (so the parser accepts it) and reference it from an assignment.
+        Such init symbols must be excluded from ``get_constants_order`` so they
+        are NOT requested from the dataset's initial conditions (which only hold
+        real states/constants) and do NOT collide with the positional "inits"
+        array. Their value still resolves from y0 at runtime.
+        """
+        model = ctx.Model(name="InitConstantModel")
+        model.add_state(s="Substrate", p="Product")
+        # Declared as a constant, exactly like a loaded model JSON would.
+        model.add_constant(s_init="Initial substrate")
+        # The init symbol is consumed via an assignment, not directly in an ODE.
+        model.add_assignment(symbol="rate", equation="k * s_init")
+        model.add_ode("s", "-rate")
+        model.add_ode("p", "rate")
+        model.parameters["k"].value = 0.5
+
+        # The init symbol must not leak into the constants order...
+        assert "s_init" not in model.get_constants_order(), (
+            "'s_init' must be excluded from the constants order"
+        )
+        assert model.get_constants_order() == [], (
+            f"Expected no real constants, got {model.get_constants_order()}"
+        )
+
+        dataset = ctx.Dataset.from_model(model)
+        dataset.add_initial(s=2.0, p=0.0)
+        dataset.add_initial(s=4.0, p=0.0)
+
+        # ...so extracting the constants matrix no longer raises KeyError.
+        constants = dataset.to_y0_matrix(state_order=model.get_constants_order())
+        assert constants.shape == (2, 0), (
+            f"Expected an empty (n_meas, 0) constants matrix, got {constants.shape}"
+        )
+
+        config = ctx.SimulationConfig(nsteps=4, t0=0, t1=2)
+        sim_dataset = model.simulate(dataset=dataset, config=config)
+
+        # p accumulates at the constant rate k * s_init, so it is linear with
+        # slope k * s_init, using each measurement's own initial value of s.
+        times = jnp.linspace(0, 2, 4)
+        for i, s_init in enumerate([2.0, 4.0]):
+            expected_p = 0.5 * s_init * times
+            actual_p = sim_dataset.measurements[i].data["p"]
+            assert jnp.abs(actual_p - expected_p).sum() < TOLERANCE, (  # type: ignore
+                f"p should grow with slope k*s_init={0.5 * s_init} for "
+                f"measurement {i}. Expected: {expected_p}, Got: {actual_p}"
+            )

--- a/tests/integration/test_simulation.py
+++ b/tests/integration/test_simulation.py
@@ -77,3 +77,67 @@ class TestSimulation:
         assert actual_initial_2 == expected_initial_2, (
             f"Second measurement initial conditions mismatch. Expected: {expected_initial_2}, Got: {actual_initial_2}"
         )
+
+    def test_simulation_with_init_symbol(self):
+        """Test that "{state}_init" symbols reuse a state's initial value.
+
+        The model uses two states:
+        - ``s`` decays exponentially: ds/dt = -k * s
+        - ``p`` accumulates at a rate equal to the *initial* value of ``s``:
+          dp/dt = s_init
+
+        Because the rate of ``p`` is the constant initial value ``s_init`` (and
+        NOT the decaying current value of ``s``), the analytical solution for
+        ``p`` is exactly linear:  p(t) = p0 + s_init * t. This makes it trivial
+        to verify that the initial value was used rather than the live state.
+        """
+        # Build the model. `s_init` should be recognised as an init reference,
+        # not turned into a free parameter.
+        model = ctx.Model(name="InitReuseModel")
+        model.add_state(s="Substrate", p="Product")
+        model.add_ode("s", "-k * s")
+        model.add_ode("p", "s_init")
+        model.parameters["k"].value = 1.0
+
+        # `s_init` must be tracked as an init on the p-equation and must NOT
+        # appear among the model parameters.
+        assert "s" in model.odes["p"].inits, (
+            "Expected 's' to be tracked as an init reference on the p-equation"
+        )
+        assert "s_init" not in model.parameters, (
+            "'s_init' must not be registered as a fittable parameter"
+        )
+
+        # Two measurements with different initial substrate concentrations.
+        dataset = ctx.Dataset.from_model(model)
+        dataset.add_initial(s=2.0, p=0.0)
+        dataset.add_initial(s=5.0, p=0.0)
+
+        # 4 time points from t=0 to t=3 -> [0, 1, 2, 3]
+        config = ctx.SimulationConfig(nsteps=4, t0=0, t1=3)
+        sim_dataset = model.simulate(dataset=dataset, config=config)
+
+        times = jnp.array([0.0, 1.0, 2.0, 3.0])
+
+        # p grows linearly with slope == initial value of s.
+        expected_p_1 = 2.0 * times  # s_init = 2.0
+        actual_p_1 = sim_dataset.measurements[0].data["p"]
+        assert jnp.abs(actual_p_1 - expected_p_1).sum() < TOLERANCE, (  # type: ignore
+            f"p should grow linearly with slope s_init=2.0. "
+            f"Expected: {expected_p_1}, Got: {actual_p_1}"
+        )
+
+        expected_p_2 = 5.0 * times  # s_init = 5.0
+        actual_p_2 = sim_dataset.measurements[1].data["p"]
+        assert jnp.abs(actual_p_2 - expected_p_2).sum() < TOLERANCE, (  # type: ignore
+            f"p should grow linearly with slope s_init=5.0. "
+            f"Expected: {expected_p_2}, Got: {actual_p_2}"
+        )
+
+        # Sanity check: s itself still decays exponentially (s = s0 * exp(-t)),
+        # confirming the init symbol did not freeze the live state.
+        expected_s_1 = 2.0 * jnp.exp(-times)
+        actual_s_1 = sim_dataset.measurements[0].data["s"]
+        assert jnp.abs(actual_s_1 - expected_s_1).sum() < TOLERANCE, (  # type: ignore
+            f"s should decay exponentially. Expected: {expected_s_1}, Got: {actual_s_1}"
+        )


### PR DESCRIPTION
This pull request introduces a robust mechanism for referencing the initial value of any state in model equations using the `{state}_init` symbol. It ensures that initial values are resolved dynamically from simulation initial conditions, both during standard simulations and when using surrogate models or MCMC with sampled initial conditions. Additionally, the documentation and tests have been updated to reflect and validate this new feature.

**Support for referencing initial values in equations:**

- Equations can now reference the initial value of any state using the `{state}_init` suffix. These symbols are resolved from the simulation's initial conditions, not registered as parameters, and are validated to ensure the referenced state exists in the model. [[1]](diffhunk://#diff-dc309ed77a89d9566e08b0af87a81cb39c03f45dfbb56cd239c1acb577987ce9R26) [[2]](diffhunk://#diff-dc309ed77a89d9566e08b0af87a81cb39c03f45dfbb56cd239c1acb577987ce9R63-R73) [[3]](diffhunk://#diff-d0919fa5180efa10437c7ddd0501945bc2c0cace3abe9201b9619f3ee4e5c746R136-R153) [[4]](diffhunk://#diff-602724c635619378aaa059ca6498d03d90409f093d1b5f33201499fd96a6efbaL304-R304)

**Simulation and surrogate model integration:**

- The simulation stack and surrogate simulation paths have been updated so that `{state}_init` symbols are always resolved from the current initial conditions (`y0`) passed to the simulation, ensuring correct behavior when initial conditions are sampled or transformed (e.g., in MCMC or surrogate rate evaluation). [[1]](diffhunk://#diff-0ed5b3227eb4d2ba600cde87678b30931e17563ae67b74ebcb325e54095087e3R53-R56) [[2]](diffhunk://#diff-0ed5b3227eb4d2ba600cde87678b30931e17563ae67b74ebcb325e54095087e3R70) [[3]](diffhunk://#diff-0ed5b3227eb4d2ba600cde87678b30931e17563ae67b74ebcb325e54095087e3R84-R99) [[4]](diffhunk://#diff-0ed5b3227eb4d2ba600cde87678b30931e17563ae67b74ebcb325e54095087e3L161-R173) [[5]](diffhunk://#diff-0ed5b3227eb4d2ba600cde87678b30931e17563ae67b74ebcb325e54095087e3L236-R249) [[6]](diffhunk://#diff-3b38e75c33580036bbe5d6ca7dc5046a35cfd16fd90911586842aa137d7e92b1L266-R268) [[7]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394L765-L774)

**Testing and validation:**

- New integration tests verify that equations referencing `{state}_init` behave correctly, both in surrogate and full simulation paths, including when initial conditions are sampled (e.g., via `estimate_initials`). This ensures the new mechanism works end-to-end and guards against regressions.

**Minor improvements and cleanup:**

- Typing improvements and minor code cleanups to support the above changes. [[1]](diffhunk://#diff-0ed5b3227eb4d2ba600cde87678b30931e17563ae67b74ebcb325e54095087e3L3-R3) [[2]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394L419-R424) [[3]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394R69) [[4]](diffhunk://#diff-2a2cb6cc86a0f9eb3c22507d322fae0b278734b57f2755fdd9f3f8158d79e394R258)
